### PR TITLE
Updating a link so that it matches the preferred onboarding locale in IAM docs not just a random doc set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+

--- a/content/100_getting_started/110_for_students/111_set_up_an_aws_account/_index.md
+++ b/content/100_getting_started/110_for_students/111_set_up_an_aws_account/_index.md
@@ -8,8 +8,11 @@ tags:
 
 ## Set up an AWS account
 
-Follow these steps if you need to setup an AWS account for yourself. If you are in a workshop or classroom setting, ask your instructor about accounts that may have been set up for you.
+Follow these steps if you need to setup an AWS account for yourself. If you are in a workshop or classroom setting, 
+ask your instructor about accounts that may have been set up for you.
 
-1. Create a new AWS account following [this guide](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
-2. Create an Admin user following [this guide](https://docs.aws.amazon.com/mediapackage/latest/ug/setting-up-create-iam-user.html)
+1. Create a new AWS account by following the [How do I create and activate a new AWS account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
+   tutorial. 
+2. Use the [Create your first IAM Admin user](https://docs.aws.amazon.com/mediapackage/latest/ug/setting-up-create-iam-user.html)
+   topic from the *AWS Identity and Access Management User Guide*. 
 3. That's it! You're ready to get started.


### PR DESCRIPTION
*Issue #, if available:*
Link in create admin user should point to the IAM user guide (https://www.awsdeeplens.recipes/100_getting_started/110_for_students/111_set_up_an_aws_account/) 

*Description of changes:*
1. added periods
2. updated text
3. updated link 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
